### PR TITLE
Fix security headers in meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,12 @@
 
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
-  <meta http-equiv="X-Frame-Options" content="DENY">
   <meta http-equiv="X-XSS-Protection" content="1; mode=block">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="geolocation=(), microphone=(), camera=()">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self';">
+  <!-- Note: X-Frame-Options and CSP frame-ancestors must be set via HTTP headers, not meta tags.
+       Consider using Cloudflare or server-side headers for clickjacking protection. -->
 
   <!-- SEO Meta Tags -->
   <meta name="description" content="PHP-FPM Process Calculator for optimizing PHP pool settings and Nginx configurations. Calculate optimal pm.max_children, pm.start_servers, and other PHP-FPM settings based on your server's RAM.">


### PR DESCRIPTION
- Remove X-Frame-Options meta tag (only works as HTTP header)
- Remove frame-ancestors from CSP meta tag (ignored in meta tags)
- Add explanatory comment about proper header configuration
- Resolves browser console warnings about invalid meta tag usage